### PR TITLE
Feature/femur isolation

### DIFF
--- a/AnAppleADay/Views/ModelView.swift
+++ b/AnAppleADay/Views/ModelView.swift
@@ -33,7 +33,7 @@ struct ModelView: View {
             
             if let modelEntity {
                                 
-                modelEntity.transform.scale = [0.0015, 0.0015, 0.0015]
+                modelEntity.transform.scale = [0.003, 0.003, 0.003]
                 
                 modelEntity.transform.rotation = .init(
                     angle: -.pi*1.5,

--- a/AnAppleADay/Views/ModelView.swift
+++ b/AnAppleADay/Views/ModelView.swift
@@ -14,7 +14,9 @@ struct ModelView: View {
     let dataSet: DicomDataSet
     
     @State private var error: Error? = nil
-    @State private var modelEntity: Entity? = nil
+    
+    @State private var bonesEntity: Entity? = nil
+    @State private var arteriesEntity: Entity? = nil
     
     var body: some View {
         
@@ -22,49 +24,85 @@ struct ModelView: View {
             
             Task.detached(priority: .utility) {
                 do {
-                    let modelEntity = try await bootstrap()
+                    let bonesEntity = try await generateEntity(
+                        300.0,
+                        .white,
+                        [0, 150, 50, 175, 500, 625],
+                        [0, 50, 500]
+                    )
                     
-                    await MainActor.run { self.modelEntity = modelEntity }
+                    let arteriesEntity = try await generateEntity(
+                        650.0,
+                        .red,
+                        [60, 150, 100, 175, 500, 625],
+                        [0, 50, 500]
+                    )
+                    
+                    await MainActor.run {
+                        arteriesEntity.isEnabled = false
+                        self.bonesEntity = bonesEntity
+                        self.arteriesEntity = arteriesEntity
+                    }
                     
                 } catch { await MainActor.run { self.error = error } }
             }
             
         } update: { content in
             
-            if let modelEntity {
-                                
-                modelEntity.transform.scale = [0.003, 0.003, 0.003]
-                
-                modelEntity.transform.rotation = .init(
-                    angle: -.pi*1.5,
-                    axis: [1, 0, 0]
-                )
-                
-                content.add(modelEntity)
+            if let bonesEntity {
+                bonesEntity.transform.scale = [0.003, 0.003, 0.003]
+                bonesEntity.transform.rotation = .init(angle: -.pi*1.5, axis: [1, 0, 0])
+                content.add(bonesEntity)
+            }
+            
+            if let arteriesEntity {
+                arteriesEntity.transform.scale = [0.003, 0.003, 0.003]
+                arteriesEntity.transform.rotation = .init(angle: -.pi*1.5, axis: [1, 0, 0])
+                content.add(arteriesEntity)
             }
         }
         .overlay {
-            if modelEntity == nil, let error {
+            if let error {
                 ErrorView(error: error)
                 
-            } else if modelEntity == nil { ProgressModelView() }
+            } else if bonesEntity == nil ||
+                      arteriesEntity == nil { ProgressModelView() }
+        }
+        .ornament(attachmentAnchor: .scene(.bottomFront)) {
+            
+            if let bonesEntity, let arteriesEntity {
+                
+                Button("Toggle Bones/Arteries") {
+                    bonesEntity.isEnabled.toggle()
+                    arteriesEntity.isEnabled.toggle()
+                }
+                .glassBackgroundEffect()
+            }
         }
     }
     
-    func bootstrap() async throws -> Entity {
+    func generateEntity(
+        _ threshold: Double,
+        _ color: UIColor,
+        _ box: [Double],
+        _ translation: [Double]
+        
+    ) async throws -> Entity {
         
         let visualizationToolkit: VisualizationToolkit = try .init()
         
         let dicom3DURL: URL = try visualizationToolkit.generateDICOM(
             fromDirectory: dataSet.url,
-            withName: dataSet.name,
-            threshold: 300.0
+            withName: dataSet.name + "-\(threshold)",
+            threshold: threshold,
+            boxBounds: box,
+            translationBounds: translation
         )
 
         let modelEntity = try await ModelEntity(contentsOf: dicom3DURL)
         
         modelEntity.model?.materials = [
-            SimpleMaterial(color: .white, isMetallic: false)
+            SimpleMaterial(color: color, isMetallic: false)
         ]
         
         return modelEntity

--- a/AnAppleADay/VisualizationToolkit/VTKWrapper.h
+++ b/AnAppleADay/VisualizationToolkit/VTKWrapper.h
@@ -42,20 +42,32 @@
 - (BOOL)isVTKFunctional;
 
 /// @brief Reads a directory of DICOM files, reconstructs a 3D surface using Marching Cubes,
-///        and exports the resulting model as a ModelIO-supported file format.
+/// optionally trims and translates it, and exports the resulting model.
 ///
-/// This method uses @c vtkDICOMImageReader to load a series of DICOM slices from
-/// the specified directory. It then applies a Marching Cubes filter at the provided
-/// threshold value to extract an isosurface. The result is saved to @c cachePath.
+/// This method uses @c vtkDICOMImageReader to load a series of DICOM slices from the specified directory.
+/// It then applies a Marching Cubes filter at the provided threshold value to extract an isosurface.
+/// If valid bounds are provided (i.e. both @p boxBounds and @p translationBounds are non-NULL), the
+/// extracted model is trimmed to the region defined by @p boxBounds using a bounding box filter and then
+/// translated so that its minimum coordinate aligns with (0,0,0) using @p translationBounds.
+/// Finally, the resulting (trimmed and/or shifted) polydata is exported using a common export method.
 ///
-/// @param dicomDir The filesystem path to a directory containing DICOM files.
+/// If either @p boxBounds or @p translationBounds is NULL, the model is exported untrimmed.
+///
+/// @param dicomDir The filesystem path to the directory containing DICOM files.
 /// @param fileName The base file name (without extension) for the output file.
-/// @param threshold The isosurface threshold used by Marching Cubes. Typically
-///        a Hounsfield Unit for CT data.
-/// @return The full filesystem path to the generated model, or nil on failure.
+/// @param threshold The isosurface threshold used by Marching Cubes (typically in Hounsfield units).
+/// @param boxBounds A pointer to an array of 6 double values representing the bounding box in the form
+///                  [xmin, xmax, ymin, ymax, zmin, zmax] used to trim the model. Must be non-NULL to trim.
+/// @param translationBounds A pointer to an array of 3 double values representing the translation vector
+///                          [tx, ty, tz] that shifts the trimmed model so its minimum is at (0,0,0).
+///                          Must be non-NULL to apply translation.
+///
+/// @return The full filesystem path to the generated model file, or nil if an error occurs.
 - (NSString *)generate3DModelFromDICOMDirectory:(NSString *)dicomDir
                                        fileName:(NSString *)fileName
-                                      threshold:(double)threshold;
+                                      threshold:(double)threshold
+                                      boxBounds:(const double [])boxBounds
+                              translationBounds:(const double [])translationBounds;
 
 /// @brief Initializes a new instance of VTKWrapper with a specific output directory.
 ///

--- a/AnAppleADay/VisualizationToolkit/VisualizationToolkit.swift
+++ b/AnAppleADay/VisualizationToolkit/VisualizationToolkit.swift
@@ -99,13 +99,19 @@ struct VisualizationToolkit {
     ///   - directoryURL: The file URL to the directory containing the DICOM files.
     ///   - fileName: The base file name (without extension) to use for the output model.
     ///   - threshold: The isosurface threshold value (e.g., in Hounsfield units for CT data).
+    ///   - boxBounds: An optional array of 6 double values representing the bounding box in the form
+    ///                  [xmin, xmax, ymin, ymax, zmin, zmax] used to trim the model. Must be not nil to trim.
+    ///   - translationBounds: An optional array of 3 double values representing the translation vector
+    ///                        [tx, ty, tz] that shifts the trimmed model so its minimum is at (0,0,0). Must be not nil to apply translation.
     /// - Returns: The file URL of the generated USD model.
     /// - Throws: `DcmVisionError.failedToGenerateModel` if VTKWrapper fails to generate the PLY;
     ///           `DcmVisionError.conversionToUSDFailed` if the conversion to USD fails.
     func generateDICOM(
         fromDirectory directoryURL: URL,
         withName fileName: String,
-        threshold: Double
+        threshold: Double,
+        boxBounds: [Double]? = nil,
+        translationBounds: [Double]? = nil
     ) throws -> URL {
         
         if let cachedURL = try? getNamedUSDFromCache(fileName) {
@@ -115,7 +121,9 @@ struct VisualizationToolkit {
         guard let vtkOutput = vtkWrapper.generate3DModel(
             fromDICOMDirectory: directoryURL.path(percentEncoded: false),
             fileName: fileName,
-            threshold: threshold
+            threshold: threshold,
+            boxBounds: boxBounds,
+            translationBounds: translationBounds
         ) else {
             throw Error.failedToGenerateModel
         }

--- a/AnAppleADay/VisualizationToolkit/VisualizationToolkit.swift
+++ b/AnAppleADay/VisualizationToolkit/VisualizationToolkit.swift
@@ -21,6 +21,7 @@ struct VisualizationToolkit {
         case invalidFile
         case failedToGenerateModel
         case conversionToUSDFailed
+        case invalidConfiguration
     }
     
     // MARK: - Properties
@@ -88,24 +89,40 @@ struct VisualizationToolkit {
     
     // MARK: - Public Methods
     
-    /// Generates a 3D model from a DICOM dataset and converts it to USD.
+    /// Generates a 3D model from a DICOM dataset and converts it to a USD file.
     ///
-    /// This method first calls the private `getNamedUSDFromCache(:_)` to check if the requested model
-    /// has already been cached. If not, it uses the VTKWrapper to read a directory of DICOM files,
-    /// apply a Marching Cubes isosurface extraction using the specified threshold, and export the resulting
-    /// model as a PLY file. The PLY file is then loaded into a ModelIO asset and exported as a USD file.
+    /// This function first checks whether a USD version of the requested model is already cached by calling
+    /// `getNamedUSDFromCache(_:)`. If a cached model is found, its URL is returned immediately.
+    ///
+    /// If no cached model exists, the function proceeds to use the VTKWrapper to:
+    ///
+    /// 1. Read the DICOM files from the provided directory.
+    /// 2. Apply a Marching Cubes isosurface extraction at the specified threshold (in Hounsfield units).
+    /// 3. Optionally trim the resulting 3D model to a region of interest using the provided bounds:
+    ///    - `boxBounds`: A 6-element array ([xmin, xmax, ymin, ymax, zmin, zmax]) defining the bounding box.
+    ///    - `translationBounds`: A 3-element array ([tx, ty, tz]) used to translate the trimmed model so that
+    ///      its minimum coordinates align with (0,0,0).
+    ///
+    /// If either `boxBounds` or `translationBounds` is provided, they must have 6 and 3 elements respectively;
+    /// otherwise, an `Error.invalidConfiguration` is thrown and no trimming is performed.
+    /// The (optionally trimmed) model is exported as a PLY file, which is then loaded into a ModelIO asset and
+    /// converted to a USD file.
     ///
     /// - Parameters:
-    ///   - directoryURL: The file URL to the directory containing the DICOM files.
-    ///   - fileName: The base file name (without extension) to use for the output model.
-    ///   - threshold: The isosurface threshold value (e.g., in Hounsfield units for CT data).
-    ///   - boxBounds: An optional array of 6 double values representing the bounding box in the form
-    ///                  [xmin, xmax, ymin, ymax, zmin, zmax] used to trim the model. Must be not nil to trim.
-    ///   - translationBounds: An optional array of 3 double values representing the translation vector
-    ///                        [tx, ty, tz] that shifts the trimmed model so its minimum is at (0,0,0). Must be not nil to apply translation.
+    ///   - directoryURL: The file URL of the directory containing the DICOM files.
+    ///   - fileName: The base file name (without extension) for the output model.
+    ///   - threshold: The isosurface threshold (typically in Hounsfield units for CT data) used in the Marching Cubes algorithm.
+    ///   - boxBounds: An optional array of 6 doubles ([xmin, xmax, ymin, ymax, zmin, zmax]) that defines the region to trim the model.
+    ///   Pass nil to skip  trimming but be aware that translationBounds needs to be nil in this case
+    ///   - translationBounds: An optional array of 3 doubles ([tx, ty, tz]) that defines the translation vector
+    ///   to apply to the trimmed model so its  minimum aligns with (0,0,0). Must be provided if boxBounds is non-nil.
+    ///
     /// - Returns: The file URL of the generated USD model.
-    /// - Throws: `DcmVisionError.failedToGenerateModel` if VTKWrapper fails to generate the PLY;
-    ///           `DcmVisionError.conversionToUSDFailed` if the conversion to USD fails.
+    ///
+    /// - Throws:
+    ///   - `DcmVisionError.failedToGenerateModel` if the VTKWrapper fails to generate the PLY file.
+    ///   - `DcmVisionError.conversionToUSDFailed` if the conversion to USD fails.
+    ///   - `Error.invalidConfiguration` if the provided bounds arrays do not contain the expected number of elements.
     func generateDICOM(
         fromDirectory directoryURL: URL,
         withName fileName: String,
@@ -118,6 +135,14 @@ struct VisualizationToolkit {
             return cachedURL
         }
             
+        if let boxBounds, boxBounds.count != 6 {
+            throw Error.invalidConfiguration
+        }
+        
+        if let translationBounds, translationBounds.count != 3 {
+            throw Error.invalidConfiguration
+        }
+        
         guard let vtkOutput = vtkWrapper.generate3DModel(
             fromDICOMDirectory: directoryURL.path(percentEncoded: false),
             fileName: fileName,
@@ -130,6 +155,7 @@ struct VisualizationToolkit {
             
         return try convertToUSD(vtkOutput)
     }
+
     
     // MARK: - Initialization
     


### PR DESCRIPTION
This pull request aims to merge the following functionality:
- The VisualizationToolkit allows to forward parameters for trimming the resulting 3D models
- The current implementation offers an arbitrary trim, obtained from the DICOM dataset that we are currently testing the software with, that isolates the femural region
- The Volumetric window hosts two entities, the exact same model but generated twice with different HF thresholds (300 for bones and 650 for arteries), and trimmed differently in order to retain only the necessary visual info
- The two entities can be toggled on and off using an ornamental button placed at volume's bottom front

In conclusion all of these changes aim to offer a specific and accurate femural rapresentation with the possibility to exclude most of the bones, for a clearer rendering of the femural artery